### PR TITLE
Manually add a slug to every post

### DIFF
--- a/_posts/2018-01-14-update.md
+++ b/_posts/2018-01-14-update.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Week Ending January 14, 2017
+slug: 2018-01-14-update
 ---
 
 Community Meeting Summary

--- a/_posts/2018-01-21-update.md
+++ b/_posts/2018-01-21-update.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Week Ending January 21, 2018
+slug: 2018-01-21-update
 ---
 
 ## Community Meeting Summary

--- a/_posts/2018-01-28-update.md
+++ b/_posts/2018-01-28-update.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Week Ending January 28, 2018
+slug: 2018-01-28-update
 ---
 
 ## Community Meeting Summary

--- a/_posts/2018-02-05-update.md
+++ b/_posts/2018-02-05-update.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: "Special Edition: Week Ending February 4, 2018"
+slug: 2018-02-05-update
 ---
 
 This week, we have a Special Edition of LWKD.  Instead of the usual list of changes, we will be covering two project areas: changes to project structure announced by the steering committee, and the list of proposed features for the 1.10 release.

--- a/_posts/2018-02-11-update.md
+++ b/_posts/2018-02-11-update.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Week Ending Feburary 12, 2018
+slug: 2018-02-11-update
 ---
 
 You may now [subscribe to LWKD by email](http://eepurl.com/dkBy_j) using MailChimp.  We also have a [Twitter account](https://twitter.com/LWKDNews).

--- a/_posts/2018-02-18-update.md
+++ b/_posts/2018-02-18-update.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Week Ending Feburary 18, 2018
+slug: 2018-02-18-update
 ---
 
 ## Community Meeting Summary

--- a/_posts/2018-02-25-update.md
+++ b/_posts/2018-02-25-update.md
@@ -2,6 +2,7 @@
 layout: post
 title: Week Ending Feburary 25, 2018
 date: 2018-02-27 08:00:00 -0000
+slug: 2018-02-25-update
 ---
 
 We now have an [RSS Feed](/feed.xml) for Kubernetes fans who like blog readers.

--- a/_posts/2018-03-04-update.md
+++ b/_posts/2018-03-04-update.md
@@ -2,6 +2,7 @@
 layout: post
 title: Week Ending March 4, 2018
 date: 2018-03-05 12:00:00 -0000
+slug: 2018-03-04-update
 ---
 
 ## Community Meeting Summary

--- a/_posts/2018-03-18-update.md
+++ b/_posts/2018-03-18-update.md
@@ -2,6 +2,7 @@
 layout: post
 title: Week Ending March 18, 2018
 date: 2018-03-19 16:00:00 -0000
+slug: 2018-03-18-update
 ---
 
 There was no LWKD issue last week due to 1.10 release prep.  Which means you missed nothing, because we're in [code freeze](https://github.com/kubernetes/sig-release/blob/master/releases/release-1.10/release-1.10.md), which means all of the merges are for 1.10 features and bug fixes.  We'll detail those from the last 2 weeks, below.

--- a/_posts/2018-03-25-update.md
+++ b/_posts/2018-03-25-update.md
@@ -2,13 +2,14 @@
 layout: post
 title: Week Ending March 25, 2018
 date: 2018-03-27 22:00:00 -0000
+slug: 2018-03-25-update
 ---
 
 In case you somehow missed it, [Kubernetes 1.10 has been released](http://blog.kubernetes.io/2018/03/kubernetes-1.10-stabilizing-storage-security-networking.html).  Go grab it, you can read LWKD while it deploys.
 
 ## Community Meeting Summary
 
-[Andy Goldstein](https://github.com/ncdc) kicked off the [Community Meeting](https://docs.google.com/document/d/1VQDIAB0OqiSjIHI8AWMvSdceWhnz56jNpZrLs6o7NJY) with a demo of Heptio's [Ark](https://github.com/heptio/ark), a tool that lets you back up your Kubernetes cluster, including configurations and PVs.  Or, at least it will once it's done; they're looking for contributors.  
+[Andy Goldstein](https://github.com/ncdc) kicked off the [Community Meeting](https://docs.google.com/document/d/1VQDIAB0OqiSjIHI8AWMvSdceWhnz56jNpZrLs6o7NJY) with a demo of Heptio's [Ark](https://github.com/heptio/ark), a tool that lets you back up your Kubernetes cluster, including configurations and PVs.  Or, at least it will once it's done; they're looking for contributors.
 
 [Cole Mickens](https://github.com/colemickens) gave SIG-Azure's update. They are moving the Azure CloudProvider to its own repo.  There are a lot of Azure compatibilty features in 1.10, and more planned for later relases.  [SIG-Node's update](https://docs.google.com/presentation/d/1P267xBGQtLprbVV-XStpVt8c-um6NqBmQLEIOKhmJAs/edit?usp=sharing) from [Derek Carr](https://github.com/derekwaynecarr) included the new [CRI Testing Policy](https://github.com/kubernetes/community/blob/master/contributors/devel/cri-testing-policy.md), local storage isolation, debug containers, and container log rotation.  He applauded the [Resource Mangement Workgroup](https://github.com/kubernetes/community/tree/master/wg-resource-management) for getting CPU pinning, hugepages, and device plugins into beta for 1.10.  SIG-Node is working on their SIG charter, as well as a secure container spec.  Finally, [Casey Davenport](https://github.com/caseydavenport) of SIG-Network explained their [current efforts to convert internal Kubernetes communications to IPv6](https://github.com/kubernetes/features/issues/508), the upcoming switch from kube-dns to CoreDNS, and their work on implementing IPVS support for kube-proxy, which has [run into some snags](https://github.com/kubernetes/kubernetes/issues?q=is%3Aopen+is%3Aissue+label%3Aarea%2Fipvs) and is currently stalled.  They did a survey in February on how people use Ingress and [shared the results](https://github.com/bowei/k8s-ingress-survey-2018).
 

--- a/_posts/2018-04-02-update.md
+++ b/_posts/2018-04-02-update.md
@@ -2,6 +2,7 @@
 layout: post
 title: Week Ending April 1, 2018
 date: 2018-04-02 22:00:00 -0000
+slug: 2018-04-02-update
 ---
 
 ## Community Meeting Summary

--- a/_posts/2018-04-09-update.md
+++ b/_posts/2018-04-09-update.md
@@ -2,6 +2,7 @@
 layout: post
 title: Week Ending April 8, 2018
 date: 2018-04-10 18:00:00 -0000
+slug: 2018-04-09-update
 ---
 
 ## Community Meeting Summary

--- a/_posts/2018-04-16-update.md
+++ b/_posts/2018-04-16-update.md
@@ -2,6 +2,7 @@
 layout: post
 title: Week Ending April 15, 2018
 date: 2018-04-16 22:00:00 -0000
+slug: 2018-04-16-update
 ---
 
 ## Community Meeting Summary

--- a/_posts/2018-04-23-update.md
+++ b/_posts/2018-04-23-update.md
@@ -2,13 +2,14 @@
 layout: post
 title: Week Ending April 22, 2018
 date: 2018-04-23 20:00:00 -0000
+slug: 2018-04-23-update
 ---
 
 Note: there will be no LWKD update next week due to KubeCon Europe.
 
 ## Community Meeting Summary
 
-Matt Rikard kicked off last week's [Community Meeting](http://bit.ly/k8scommunity) with a demo of [Skaffold](https://github.com/GoogleCloudPlatform/skaffold), Google's OSS tool for CI/CD development targeting Kubernetes clusters.  
+Matt Rikard kicked off last week's [Community Meeting](http://bit.ly/k8scommunity) with a demo of [Skaffold](https://github.com/GoogleCloudPlatform/skaffold), Google's OSS tool for CI/CD development targeting Kubernetes clusters.
 
 SIG updates:  Maciej Szulik explained the work that [SIG-CLI](https://github.com/kubernetes/community/tree/master/sig-cli) has been doing on "printing" object information (meaning formatting it for display through kubectl or the API).  In 1.11, this is moving to server-side formatting which supports pretty-printing of custom Kubernetes objects like CRDs. [SIG-AWS](https://github.com/kubernetes/community/tree/master/sig-aws)'s Justin Santa Barbara mentioned their first [SIG repository](https://github.com/kubernetes/community/blob/master/kubernetes-repositories.md#sig-repositories): [aws-encryption-provider](https://github.com/kubernetes-sigs/aws-encryption-provider).  However, moving AWS out to Cloud Provider API is apparently stalled, and SIG-AWS could use help.  Adam Worrell gave the [SIG-GCP](https://github.com/kubernetes/community/tree/master/sig-gcp) update because he is the sole Lead for the SIG, something they're working on fixing. They've been having diffculty getting a lot of community interest in the SIG.
 

--- a/_posts/2018-05-13-update.md
+++ b/_posts/2018-05-13-update.md
@@ -2,13 +2,14 @@
 layout: post
 title: Week Ending May 13, 2018
 date: 2018-05-15 20:00:00 -0000
+slug: 2018-05-13-update
 ---
 
 *LWKD has been on hiatus due to KubeConEU and multiple industry conferences.  As such, this issue covers the last two weeks of development.  Mind the gap?  LWKD is [looking for contributors](https://github.com/lwkd/lwkd.github.io/issues/8)*
 
 ## Community Meeting Summary
 
-The demo that kicked off [the community meeting](http://bit.ly/k8scommunity) was [Ambassador](https://www.getambassador.io/), a simple-to-configure routing tool for Kubernetes built on [Envoy](https://www.envoyproxy.io/), which can replace Ingress for some users.  
+The demo that kicked off [the community meeting](http://bit.ly/k8scommunity) was [Ambassador](https://www.getambassador.io/), a simple-to-configure routing tool for Kubernetes built on [Envoy](https://www.envoyproxy.io/), which can replace Ingress for some users.
 
 [SIG-Architecture](https://github.com/kubernetes/community/tree/master/sig-architecture), according to Brian Grant, is finalizing their [charter](https://github.com/kubernetes/community/pull/2074), as well as working with SIG-PM on the KEP process.  They also want to create a formal review process for API changes.  Interested?  Join their weekly [office hours](https://github.com/kubernetes/community/blob/master/sig-architecture/README.md) to discuss things.  [SIG-Contributor Experience](https://github.com/kubernetes/community/tree/master/sig-contributor-experience) is thinking of launching a [contributor site](https://github.com/kubernetes/community/blob/master/keps/sig-contributor-experience/0005-contributor-site.md), per Paris Pittman.  The first part of this is a [Discourse forum](http://discuss.kubernetes.io/), which was launched this week.  They are planning a contributor survey for June, have started the [Developers Guide](https://github.com/kubernetes/community/issues/1919), and [need mentors](https://goo.gl/forms/3ISrNbTkYqExWzKw1) as always.
 

--- a/_posts/2018-05-20-update.md
+++ b/_posts/2018-05-20-update.md
@@ -2,6 +2,7 @@
 layout: post
 title: Week Ending May 20, 2018
 date: 2018-05-22 15:00:00 -0000
+slug: 2018-05-20-update
 ---
 
 Prepare yourself for an extra-long LWKD!  Apparently once everyone got home from KubeCon EU, they merged all the code they discussed there, especially the Kubeadm team.  More than 70 changes worth noting, below.

--- a/_posts/2018-05-27-update.md
+++ b/_posts/2018-05-27-update.md
@@ -2,6 +2,7 @@
 layout: post
 title: Week Ending May 27, 2018
 date: 2018-05-27 08:00:00 -0000
+slug: 2018-05-27-update
 ---
 
 ## Community Meeting Summary
@@ -44,7 +45,7 @@ The Burndown Meetings for Code Slush and Code Freeze will be [at different times
 
 Since we're into Code Slush, SIG Testing has been fixing many tests.
 
-* Several E2E tests are being "upgraded" to Conformance tests, including [pod cgroup test](https://github.com/kubernetes/kubernetes/pull/64472).  
+* Several E2E tests are being "upgraded" to Conformance tests, including [pod cgroup test](https://github.com/kubernetes/kubernetes/pull/64472).
 * [Fix preemption tests](https://github.com/kubernetes/kubernetes/pull/62933).
 * [Enable full ENV configuration](https://github.com/kubernetes/kubernetes/pull/60636) for local testing.
 

--- a/_posts/2018-06-10-update.md
+++ b/_posts/2018-06-10-update.md
@@ -2,6 +2,7 @@
 layout: post
 title: Week Ending June 10, 2018
 date: 2018-06-11 14:00:00 -0000
+slug: 2018-06-10-update
 ---
 
 Welcome to a special guest-editor edition of LWKD. Our usual


### PR DESCRIPTION
To ensure the correct `<id>` tag in the RSS feed, we need to set the slug manually. Bit annoying, but so it goes.

Technical explanation: Jekyll parses the filename `2018-01-01-update.md` and takes `2018-01-01` as a the post date and `update` as the post slug. We override the URL for each post to not actually use the slug, but the `<id>` tag in the RSS uses the slug rather than the post URL for some reason. Sigh.

Fixes #10 