### PR TITLE
Fix BootStrapToken API link

### DIFF
--- a/_posts/2021-07-04-update.md
+++ b/_posts/2021-07-04-update.md
@@ -39,7 +39,7 @@ And for all the other use cases, definitely check out the [topology aware hints]
 * Certificate Signing Requests [have configurable expirations](https://github.com/kubernetes/kubernetes/pull/99494)
 * client-go supports the [new APIServer tracing requests](https://github.com/kubernetes/kubernetes/pull/103218)
 * ReadWriteOncePod is [enforced during scheduling](https://github.com/kubernetes/kubernetes/pull/103082)
-* kubeadm [BootStrapToken API](https://github.com/kubernetes/kubernetes/pull/103082) is changing
+* kubeadm [BootStrapToken API](https://github.com/kubernetes/kubernetes/pull/102964) is changing
 * Set the [log level of kube-proxy](https://github.com/kubernetes/kubernetes/pull/98306) on the fly
 * Usage of go-bindata replaced [with //go:embed](https://github.com/kubernetes/kubernetes/pull/99829) all through our code
 * Delegated authz [gets metrics](https://github.com/kubernetes/kubernetes/pull/100339)


### PR DESCRIPTION
I found the typo in the latest issue.

> * kubeadm [BootStrapToken API](https://github.com/kubernetes/kubernetes/pull/103082) is changing

The link is wrong one.  This PR fixed the link with https://github.com/kubernetes/kubernetes/pull/102964.  I'm not sure it is the correct one tough. 