### PR TITLE
Week of April 5, 2026: Developer News

### DIFF
--- a/_posts/2026-04-05-update.md
+++ b/_posts/2026-04-05-update.md
@@ -7,6 +7,22 @@ slug: 2026-04-05-update
 
 ## Developer News
 
+* The NVIDIA DRA Driver for GPUs has been [officially onboarded as a SIG Node
+  subproject](https://github.com/kubernetes/community/pull/8921) in kubernetes-sigs, formally
+  moving community governance of the GPU DRA driver that NVIDIA donated at the 2026 KubeCon+CloudNativeCon EU into
+  upstream Kubernetes.
+
+* A [CPU DRA Driver v0.1.0](https://github.com/kubernetes-sigs/dra-driver-cpu/releases/tag/v0.1.0)
+  has been released, enabling exclusive CPU pinning for workloads via the DRA framework with
+  support for aligning CPU allocations with other DRA-managed resources such as NICs and GPUs.
+
+* The Kubernetes contributor guide has been updated with a new [AI usage and disclosure
+  policy](https://github.com/kubernetes/community/pull/8918); all contributors should review the
+  changes before using AI tools in their Kubernetes contributions.
+
+* The [ingress-nginx and ingate Slack channels have been
+  archived](https://github.com/kubernetes/community/pull/8919) following the project's retirement
+  in March; contributors should migrate to #gateway-api or other relevant channels.
 
 ## Release Schedule
 


### PR DESCRIPTION
Adding the Developer News section for the week ending April 5, 2026.