### PR TITLE
Week Ending April 19, 2026: Developer News

### DIFF
--- a/_posts/2026-04-19-update.md
+++ b/_posts/2026-04-19-update.md
@@ -7,6 +7,13 @@ slug: 2026-04-19-update
 
 ## Developer News
 
+[Kubernetes v1.36.0-rc.1 is live](https://groups.google.com/a/kubernetes.io/g/dev/c/SnyG24KtSxw), built with Go 1.26.2, ahead of the April 22 final release.
+
+[Kernel Module Management (KMM) operator v2.6.0](https://groups.google.com/a/kubernetes.io/g/dev/c/oR9k24KWHVM) has been released with support for image rebuild triggers, host kernel module mounts, glob patterns for file signing, and hardened container security contexts.
+
+SIG etcd has [nominated Josh Berkus (@jberkus) for a new leadership role as a co-chair](https://groups.google.com/a/kubernetes.io/g/dev); lazy consensus is open on the dev mailing list.
+
+The Kubernetes project’s [new GitHub Actions security policy](https://groups.google.com/a/kubernetes.io/g/dev/c/gvwLzCBx-hA) is now enforced at the enterprise level, so workflows using mutable action refs like tags, branches, or latest will fail and maintainers need to pin actions to full 40-character commit SHAs
 
 ## Release Schedule
 

--- a/_posts/2026-04-19-update.md
+++ b/_posts/2026-04-19-update.md
@@ -7,7 +7,7 @@ slug: 2026-04-19-update
 
 ## Developer News
 
-Kubernetes 1.36 has been released, with highlights including Dynamic Resource Allocation (DRA) graduating key features like device taints and extended resources to beta, in-place Pod resource resizing moving to beta and enabled by default, and MutatingAdmissionPolicy reaching GA; more details are available in the [official blog](kubernetes.io/blog/2026/04/22/kubernetes-v1-36-release/).
+Kubernetes 1.36 has been released, with features including fine-grained kubelet API authorization reaching GA, MutatingAdmissionPolicy graduating to stable for declarative request mutation, and new Workload Aware Scheduling features enabling group-based (PodGroup) scheduling; more details are available in the [official release blog](https://kubernetes.io/blog/2026/04/22/kubernetes-v1-36-release/).
 
 [Kernel Module Management (KMM) operator v2.6.0](https://groups.google.com/a/kubernetes.io/g/dev/c/oR9k24KWHVM) has been released with support for image rebuild triggers, host kernel module mounts, glob patterns for file signing, and hardened container security contexts.
 

--- a/_posts/2026-04-19-update.md
+++ b/_posts/2026-04-19-update.md
@@ -7,7 +7,7 @@ slug: 2026-04-19-update
 
 ## Developer News
 
-[Kubernetes v1.36.0-rc.1 is live](https://groups.google.com/a/kubernetes.io/g/dev/c/SnyG24KtSxw), built with Go 1.26.2, ahead of the April 22 final release.
+Kubernetes 1.36 has been released, with highlights including Dynamic Resource Allocation (DRA) graduating key features like device taints and extended resources to beta, in-place Pod resource resizing moving to beta and enabled by default, and MutatingAdmissionPolicy reaching GA; more details are available in the [official blog](kubernetes.io/blog/2026/04/22/kubernetes-v1-36-release/).
 
 [Kernel Module Management (KMM) operator v2.6.0](https://groups.google.com/a/kubernetes.io/g/dev/c/oR9k24KWHVM) has been released with support for image rebuild triggers, host kernel module mounts, glob patterns for file signing, and hardened container security contexts.
 

--- a/_posts/2026-04-19-update.md
+++ b/_posts/2026-04-19-update.md
@@ -11,9 +11,9 @@ slug: 2026-04-19-update
 
 [Kernel Module Management (KMM) operator v2.6.0](https://groups.google.com/a/kubernetes.io/g/dev/c/oR9k24KWHVM) has been released with support for image rebuild triggers, host kernel module mounts, glob patterns for file signing, and hardened container security contexts.
 
-SIG etcd has [nominated Josh Berkus (@jberkus) for a new leadership role as a co-chair](https://groups.google.com/a/kubernetes.io/g/dev); lazy consensus is open on the dev mailing list.
+SIG etcd has [nominated Josh Berkus (@jberkus) for a new leadership role as a co-chair](https://groups.google.com/a/kubernetes.io/g/dev/c/gvwLzCBx-hA); lazy consensus is open on the dev mailing list.
 
-The Kubernetes project’s [new GitHub Actions security policy](https://groups.google.com/a/kubernetes.io/g/dev/c/gvwLzCBx-hA) is now enforced at the enterprise level, so workflows using mutable action refs like tags, branches, or latest will fail and maintainers need to pin actions to full 40-character commit SHAs
+The Kubernetes project’s [new GitHub Actions security policy](https://groups.google.com/a/kubernetes.io/g/dev/c/gvwLzCBx-hA) is now enforced at the enterprise level, so workflows using mutable action refs like tags, branches, or latest will fail and maintainers need to pin actions to full 40-character commit SHAs.
 
 ## Release Schedule
 


### PR DESCRIPTION
Incorporating the feedback given in the [previous PR](https://github.com/kubernetes-sigs/lwkd/pull/808) and adding Developer News items for week ending April 19, 2026. 