### PR TITLE
change github actions to use commit SHA hashes

### DIFF
--- a/.github/workflows/get-releases-weekly.yaml
+++ b/.github/workflows/get-releases-weekly.yaml
@@ -19,9 +19,9 @@
         CI_COMMIT_MESSAGE: Add weekly release notes
         CI_COMMIT_AUTHOR: Release Crawler
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         - name: Set up Go
-          uses: actions/setup-go@v5
+          uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
           with:
             go-version: 1.21
         - run: go run main.go


### PR DESCRIPTION
- Change github actions to use commit SHA hashes as per [github-actions-security-policy](https://github.com/kubernetes/community/blob/main/github-management/github-actions-policy.md#github-actions-security-policy)