### PR TITLE
Update create-pull-request action to specific commit

### DIFF
--- a/.github/workflows/get-releases-weekly.yaml
+++ b/.github/workflows/get-releases-weekly.yaml
@@ -30,7 +30,7 @@
           id: date
           run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
         - name: Create Pull Request
-          uses: peter-evans/create-pull-request@v7
+          uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8
           with:
             token: ${{ secrets.GITHUB_TOKEN }}
             commit-message: Add last weeks releated Project Updates


### PR DESCRIPTION
Fix GHA run error for https://github.com/kubernetes-sigs/lwkd/actions/runs/26376896980 This should fix the Github Action failure run.

The sha version source: https://github.com/peter-evans/create-pull-request/tags

If v8 is not in approved list. We can try with following
```
│ │ 33 -     uses: peter-evans/create-pull-request@v7                                                                                                                                                                                                       │ │
│ │ 33 +     uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c8cb93d129 # v7.0.5
```