### PR TITLE
Add shoutouts documentation and template

### DIFF
--- a/STYLESHEET.md
+++ b/STYLESHEET.md
@@ -309,3 +309,15 @@ The format template for these announcements is:
 ```
 
 The changes listed are 2-4 word summaries of major changes in that release (e.g. "fix CVE 2024-0576").  The "also" portion is for listing any backported update releases at the same time.
+
+### Shoutouts
+
+The Shoutouts section recognizes contributors and community members for efforts that help improve Kubernetes.
+
+Review messages posted in the [#shoutouts channel](https://kubernetes.slack.com/archives/C92G08FGD) and edit them for clarity. Remove emojis and informal chat language while preserving the original recognition.
+
+If there are no new shoutouts, use:
+
+```
+* No shoutouts this week. Want to thank someone for special efforts to improve Kubernetes? Tag them in the #shoutouts channel.
+```

--- a/template.md
+++ b/template.md
@@ -41,4 +41,4 @@ slug: 2026-01-04-update
 
 ## Shoutouts
 
-* 
+* No shoutouts this week. Want to thank someone for special efforts to improve Kubernetes? Tag them in the #shoutouts channel.


### PR DESCRIPTION
## Summary

This PR improves the Shoutouts workflow in two ways:

### STYLESHEET.md

Adds a Shoutouts section to the stylesheet. Previously there was no guidance for the section, making it harder for new contributors to know where shoutouts come from and how they should be edited before publication.

### template.md

Adds the default shoutout message to the newsletter template:

> No shoutouts this week. Want to thank someone for special efforts to improve Kubernetes? Tag them in the #shoutouts channel.

Since each issue starts from the template, this removes the need to manually copy and paste the default message whenever there are no shoutouts. Writers can simply replace it if shoutouts are available.
