### PR TITLE
Added steering committee meeting details for 6/7 issue

### DIFF
--- a/_posts/2026-06-07-update.md
+++ b/_posts/2026-06-07-update.md
@@ -1,12 +1,17 @@
 ---
 layout: post
 title: Week Ending June 7, 2026
-date: 2026-06-10 22:00:00 -0000
+date: 2026-06-11 03:09:50 -0000
 slug: 2026-06-07-update
 ---
 
 ## Developer News
 
+## Steering Committee Meeting
+
+This month's [Steering Committee Meeting](https://docs.google.com/document/d/1qazwMIHGeF3iUh5xMJIJ6PDr-S3bNkT8tNLRkSiOkOU/edit?tab=t.0#heading=h.5gstfx3y3p7i) started out by discussing the 2026 Steering Committee Elections. Based on the feedback from last year's election retro, we are starting the process earlier this year. Antonio Ojea, Benjamin Elder and Sascha Grunert will be stepping down this year and there will be 3 spots to be elected. One feedback from the steering committee was to announce the elections earlier before folks are out for their summer vacations. Keep a lookout for the steering committee elections anouncement soon!
+
+The details of the Maintainer Summit was also discussed. The Maintainer Summit event will happen on the day before the colocated events and will only be happening at KubeCon EU and NA. If you want to have a booth in the project pavillion for a SIG or a subproject, you can request this via SIG ContribEx. The CFP announcement for the Maintainer Summit at KubeCon NA 2026 is not out yet, but is expected to be announced soon.
 
 ## Release Schedule
 


### PR DESCRIPTION
The date update is from a git commit hook that I had setup to accurately update the date before publishing. If the date set in the header is in the future, the issue will not show up in the website until that timestamp is in the past. You can ignore this change because this can be updated at the very end to the timestamp around which we will be publishing the issue.

CC: @inirah02 @darshansreenivas for the date updation logic