### PR TITLE
Week Ending June 21, 2026: Other Merges

### DIFF
--- a/_posts/2026-06-21-update.md
+++ b/_posts/2026-06-21-update.md
@@ -21,19 +21,13 @@ slug: 2026-06-21-update
 
 ## Other Merges
 
-*
-
-## Promotions
-
-*
-
-## Deprecated
-
-*
-
-## Version Updates
-
-*
+* The internal Pod conversion refactor advances with a five-PR series ([PodSpec 1–5](https://github.com/kubernetes/kubernetes/pull/139851)) reorganizing PodSpec and PodStatus internals: ExpirationSeconds, [Quobyte field order](https://github.com/kubernetes/kubernetes/pull/139852), [PodSecurityContext fields](https://github.com/kubernetes/kubernetes/pull/139853), [field reordering](https://github.com/kubernetes/kubernetes/pull/139854), and [DeprecatedServiceAccount](https://github.com/kubernetes/kubernetes/pull/139855) as groundwork for the next phase of declarative-validation generators.
+* [The watchcache interval source is refactored](https://github.com/kubernetes/kubernetes/pull/139860) in `apiserver/storage`, simplifying how the cacher pulls events from etcd watch streams.
+* Introduces the [`WatchListCompression` feature gate](https://github.com/kubernetes/kubernetes/pull/139308), enabling compressed responses for streaming `LIST` requests served through the watch cache.
+* Fixes a [scheduler bug where gated pods were not flushed at the same frequency as non-gated pods](https://github.com/kubernetes/kubernetes/pull/139331), eliminating a latency disparity for gated workloads.
+* The scheduler now [logs an error when the `GangScheduling` plugin is missing from a `GenericWorkload` configuration](https://github.com/kubernetes/kubernetes/pull/139572), making misconfiguration easier to diagnose.
+* kubelet: [the `--event-burst` CLI flag description is updated to match its actual default](https://github.com/kubernetes/kubernetes/pull/139639), correcting documentation drift.
+* Fixes a [DRA allocator bug where widening config was incorrectly scoped at the subrequest level](https://github.com/kubernetes/kubernetes/pull/139814), restoring expected allocation semantics for DRA requests with subrequests.
 
 ## Subprojects and Dependency Updates
 


### PR DESCRIPTION
Other Merges section for week ending June 21, 2026.

PodSpec internal conversion series: #139851-#139855
Other: #139860, #139308, #139331, #139572, #139639, #139814

Excluded: cherry-picks, test-only changes, pure refactors, EOL cleanup.