### PR TITLE
Week Ending June 28, 2026: Other Merges

### DIFF
--- a/_posts/2026-06-28-update.md
+++ b/_posts/2026-06-28-update.md
@@ -21,23 +21,22 @@ slug: 2026-06-29-update
 
 ## Other Merges
 
-*
+* Fixes a [dbus connection leak in the kubelet node shutdown manager](https://github.com/kubernetes/kubernetes/pull/137141) that could exhaust threads on long-running nodes.
+* kubelet: [reuses the previous context in `startPodSync`](https://github.com/kubernetes/kubernetes/pull/139850) to fix a memory leak regression introduced when each pod sync allocated a new context.
+* Fixes the [CronJob controller's rate-limiter backoff counter not being cleared](https://github.com/kubernetes/kubernetes/pull/139918) on the `(nil, nil)` sync path, leaving stale backoff state across sync iterations.
+* kubelet [only emits `FailedToRetrieveImagePullSecret` events when an image pull actually fails](https://github.com/kubernetes/kubernetes/pull/138432), eliminating spurious warnings for pods that pull cleanly with missing optional pull secrets.
+* The scheduler [includes `resourceVersion` in Pod status patches](https://github.com/kubernetes/kubernetes/pull/139602), preventing lost updates when concurrent components race to patch the same Pod.
+* Validation [rejects a zero step in `ResourceSlice` `validRange`](https://github.com/kubernetes/kubernetes/pull/139698), preventing DRA drivers from advertising malformed numeric ranges.
+* [Clarifies the kubelet error message](https://github.com/kubernetes/kubernetes/pull/139791) when a probe references a named port that cannot be resolved in the container spec.
+* The [Binding API now validates the target node name](https://github.com/kubernetes/kubernetes/pull/136776), rejecting requests with empty or malformed node names at admission.
+* kubelet/DRA: [derives claim names from the claim info cache](https://github.com/kubernetes/kubernetes/pull/139845) rather than from runtime arguments, improving consistency for DRA driver lookups.
+* kubelet [depends on `github.com/google/cadvisor/lib`](https://github.com/kubernetes/kubernetes/pull/139870), a slimmer cadvisor subpackage that reduces the kubelet's overall dependency footprint.
+* client-go [defers metrics registration to the runtime entry point](https://github.com/kubernetes/kubernetes/pull/138914) via constructor functions, eliminating implicit init-time global state for downstream consumers.
+* Adds [Windows CPU affinity tests](https://github.com/kubernetes/kubernetes/pull/139652) to the `e2e_node_windows` suite, continuing the Windows node-level test coverage build-out.
+* Declarative validation: an [ObjectMeta test suite has been wired across the core, apps, networking, storage, and scheduling API groups](https://github.com/kubernetes/kubernetes/pull/139963), extending DV coverage uniformly across the API surface ([companion PR](https://github.com/kubernetes/kubernetes/pull/139970)).
+* HPA's [`CrossVersionObjectReference.Kind` and `.Name` fields have been migrated to declarative validation](https://github.com/kubernetes/kubernetes/pull/138077).
+* The [Authorization API group has been onboarded to declarative validation](https://github.com/kubernetes/kubernetes/pull/139863).
 
-## Promotions
-
-*
-
-## Deprecated
-
-*
-
-## Version Updates
-
-*
-
-## Subprojects and Dependency Updates
-
-*
 
 ## Shoutouts
 


### PR DESCRIPTION
Other Merges (16 items) plus SELinuxMount GA promotion.
Empty Deprecated and Version Updates section headers removed per editor convention.
Skipped: cherry-picks, test-only PRs, internal benchmarks.