### PR TITLE
Change KEP-2021 status from Alpha to Beta

### DIFF
--- a/_posts/2026-07-05-update.md
+++ b/_posts/2026-07-05-update.md
@@ -37,7 +37,7 @@ In this pull request [p0lyn0mial](https://github.com/p0lyn0mial) enabled the **W
 
 [KEP-2021: HPA supports scaling to/from zero pods for object/external metrics](https://github.com/kubernetes/enhancements/blob/master/keps/sig-autoscaling/2021-scale-from-zero/README.md)
 
-This KEP enables the Horizontal Pod Autoscaler (HPA) to scale workloads from zero to many replicas and back to zero when using object or external metrics. Since CPU and memory metrics require running pods, scale-to-zero is limited to these metric types. The feature is intended to reduce costs and energy consumption for intermittently idle, resource-intensive workloads (such as GPU-based applications) while still allowing HPA to automatically scale back up when demand returns (for example, when a queue receives new messages). As of now, the KEP is still in Alpha.
+This KEP enables the Horizontal Pod Autoscaler (HPA) to scale workloads from zero to many replicas and back to zero when using object or external metrics. Since CPU and memory metrics require running pods, scale-to-zero is limited to these metric types. The feature is intended to reduce costs and energy consumption for intermittently idle, resource-intensive workloads (such as GPU-based applications) while still allowing HPA to automatically scale back up when demand returns (for example, when a queue receives new messages). As of now, the KEP is in Beta.
 
 ## Other Merges
 * Adds a [`PreemptionPolicy` field to `PodGroupSpec`](https://github.com/kubernetes/kubernetes/pull/139240) as part of KEP-5710 workload-aware preemption; the field is gated behind the `PodGroupPreemptionPolicy` feature gate and follows the same `Never` / `PreemptLowerPriority` semantics as per-pod preemption.

--- a/_posts/2026-07-05-update.md
+++ b/_posts/2026-07-05-update.md
@@ -37,7 +37,7 @@ In this pull request [p0lyn0mial](https://github.com/p0lyn0mial) enabled the **W
 
 [KEP-2021: HPA supports scaling to/from zero pods for object/external metrics](https://github.com/kubernetes/enhancements/blob/master/keps/sig-autoscaling/2021-scale-from-zero/README.md)
 
-This KEP enables the Horizontal Pod Autoscaler (HPA) to scale workloads from zero to many replicas and back to zero when using object or external metrics. Since CPU and memory metrics require running pods, scale-to-zero is limited to these metric types. The feature is intended to reduce costs and energy consumption for intermittently idle, resource-intensive workloads (such as GPU-based applications) while still allowing HPA to automatically scale back up when demand returns (for example, when a queue receives new messages). As of now, the KEP is in Beta.
+This KEP enables the Horizontal Pod Autoscaler (HPA) to scale workloads from zero to many replicas and back to zero when using object or external metrics. Since CPU and memory metrics require running pods, scale-to-zero is limited to these metric types. The feature is intended to reduce costs and energy consumption for intermittently idle, resource-intensive workloads (such as GPU-based applications) while still allowing HPA to automatically scale back up when demand returns (for example, when a queue receives new messages). At time of writing, this KEP is listed as Beta in v1.37.
 
 ## Other Merges
 * Adds a [`PreemptionPolicy` field to `PodGroupSpec`](https://github.com/kubernetes/kubernetes/pull/139240) as part of KEP-5710 workload-aware preemption; the field is gated behind the `PodGroupPreemptionPolicy` feature gate and follows the same `Never` / `PreemptLowerPriority` semantics as per-pod preemption.


### PR DESCRIPTION
The KEP is currently in beta for Kubernetes 1.37
It's been Alpha since 1.16, so the beta position is a big deal