### PR TITLE
Week Ending July 12, 2026: Other Merges and Promotions

### DIFF
--- a/_posts/2026-07-12-update.md
+++ b/_posts/2026-07-12-update.md
@@ -28,19 +28,26 @@ This KEP is currently in Alpha stage.
 
 ## Other Merges
 
-*
+* Fixes a [DRA resourceslice controller bug where an update-after-quick-delete cached stale entries](https://github.com/kubernetes/kubernetes/pull/140063), preventing subsequent updates from taking effect.
+* Adds [PodGroup as a preemption victim](https://github.com/kubernetes/kubernetes/pull/137981) in the per-pod preemption flow, part of KEP-5710 workload-aware preemption.
+* Fixes a bug where [kube-proxy did not restart on node IP changes or deletions](https://github.com/kubernetes/kubernetes/pull/138183), leaving stale network state after Node object mutations.
+* Reimplements [Workload-Aware Preemption using in-place filter reprieval](https://github.com/kubernetes/kubernetes/pull/139980) to match the design in KEP-5710.
+* Fixes a [kubelet bug where burstable pods' `memory.low` cgroup value was ineffective](https://github.com/kubernetes/kubernetes/pull/140267) due to missing ancestor cgroup coverage.
+* Adds a new [`PodGroupPostFilter` scheduler extension point](https://github.com/kubernetes/kubernetes/pull/139674) that runs after standard `PostFilter` for gang-scheduled workloads.
+* kubectl explain: adds a [`--max-depth` flag](https://github.com/kubernetes/kubernetes/pull/138809) to truncate schema output for deeply nested resources like CRDs and Pod specs.
+* kubectl: [`cluster-info dump --output-directory` creates output files with owner-only permissions](https://github.com/kubernetes/kubernetes/pull/140189), preventing world-readable exposure of potentially sensitive cluster state.
+* Lands the [core Conditional Authorization machinery](https://github.com/kubernetes/kubernetes/pull/137513) (Conditional Authz [2/n]), building on the interface rename in [#138801](https://github.com/kubernetes/kubernetes/pull/138801) to enable authorizers to evaluate condition-based decisions.
+* Fixes a [scheduler bug where `PodGroup.Status` was not updated when pods in the group had mismatched `.spec.schedulerName` or priority values](https://github.com/kubernetes/kubernetes/pull/140183).
 
 ## Promotions
 
-*
-
-## Deprecated
-
-*
+* [KEP-5207: `metrics.k8s.io` API promoted to v1 GA](https://github.com/kubernetes/kubernetes/pull/139223).
+* [KEP-3962: Storage Version Migration (SVM) promoted to GA](https://github.com/kubernetes/kubernetes/pull/138560).
 
 ## Version Updates
 
-*
+* [`github.com/google/cadvisor/lib` bumped from v0.60.3 to v0.60.4](https://github.com/kubernetes/kubernetes/pull/140385), which pulls in updated `golang.org/x/*` module versions across the tree.
+* [Structured Merge Diff bumped to v6.4.2](https://github.com/kubernetes/kubernetes/pull/140294), reverting an SMD change that had introduced a Server-Side Apply regression for nullable container types.
 
 ## Subprojects and Dependency Updates
 


### PR DESCRIPTION

Other Merges (16 items): #140063, #137981, #138183, #139980, #140267, #139674, #139993, #138809, #140189, #140056, #140323, #139419, #140294, #136705, #137513, #140183

Promotions (2 items): #139223 (metrics.k8s.io GA), #138560 (SVM GA)

Excluded:
- Dependency bumps: #140333, #140385
- release-note-none PRs: 23 items

Empty ## Deprecated and ## Version Updates section headers removed.