### PR TITLE
 release schedule 20260719

### DIFF
--- a/_posts/2026-07-19-update.md
+++ b/_posts/2026-07-19-update.md
@@ -10,7 +10,11 @@ slug: 2026-07-19-update
 
 ## Release Schedule
 
+**Next Deadline: [Code Freeze and Test Freeze](https://github.com/kubernetes/sig-release/blob/master/releases/release_phases.md#code-freeze), [July 22nd](https://www.kubernetes.dev/resources/release/#timeline)**
 
+Kubernetes v1.37 has entered Code Freeze and Test Freeze. Enhancements targeting this release should now be merge-ready with the required approvals, passing tests, and documentation PRs opened. From this point onward, only release-blocking changes should proceed.
+
+Patch releases [v1.36.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md), [v1.35.7](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md), and [v1.34.10](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md) are now available. These releases include Go updates and bug fixes.
 
 ## Featured PRs
 


### PR DESCRIPTION
Added information about the next deadline for code and test freeze, along with details on Kubernetes v1.37 and recent patch releases.