### PR TITLE
Bump actions/checkout and actions/setup-go to Node 24 ready versions

### DIFF
--- a/.github/workflows/get-releases-weekly.yaml
+++ b/.github/workflows/get-releases-weekly.yaml
@@ -19,9 +19,9 @@
         CI_COMMIT_MESSAGE: Add weekly release notes
         CI_COMMIT_AUTHOR: Release Crawler
       steps:
-        - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         - name: Set up Go
-          uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+          uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
           with:
             go-version: 1.21
         - run: go run main.go


### PR DESCRIPTION
### Description

Bump `actions/checkout` v4 → v7.0.1 and `actions/setup-go` v5 → v7.0.0 in
`.github/workflows/get-releases-weekly.yaml`, ahead of Node 20 removal from
GitHub Actions runners. Both pinned majors bundle Node 20 as their runtime.
`peter-evans/create-pull-request` is already on v8 (Node 24 ready), no change
needed there.

Relates to: https://github.com/kubernetes/website/issues/56610