### PR TITLE
Bump actions to Node 24-ready versions

### DIFF
--- a/.github/workflows/get-releases-weekly.yaml
+++ b/.github/workflows/get-releases-weekly.yaml
@@ -19,9 +19,9 @@
         CI_COMMIT_MESSAGE: Add weekly release notes
         CI_COMMIT_AUTHOR: Release Crawler
       steps:
-        - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         - name: Set up Go
-          uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+          uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
           with:
             go-version: 1.21
         - run: go run main.go


### PR DESCRIPTION
Upgrade checkout v4 → v7.0.1 and setup-go v5 → v7.0.0 before GitHub Actions drops Node 20 support on Sep 16, 2026.

See: https://github.com/actions/setup-go/blob/v7.0.0/action.yml#L30

Relates to: https://github.com/kubernetes/website/issues/56610