### PR TITLE
July 26, 2026: Other Merges, Promotions, Version Updates

### DIFF
--- a/_posts/2026-07-26-update.md
+++ b/_posts/2026-07-26-update.md
@@ -16,6 +16,27 @@ slug: 2026-07-26-update
 
 ## Other Merges
 
+* Fixes a [DRA structured allocator bug where `allocationMode: All` requests did not properly fail when a matching device was capacity-exhausted](https://github.com/kubernetes/kubernetes/pull/140769) under `DRAConsumableCapacity`.
+* kubectl: [includes the group name in the resource-not-found error message](https://github.com/kubernetes/kubernetes/pull/140759) when a resource type is requested with a group qualifier it doesn't belong to.
+* Adds [finer-grained buckets to the `watch_list_duration_seconds` metric](https://github.com/kubernetes/kubernetes/pull/140757) for better observability of watch-list operations.
+* Fixes the [error message in `PodGroupPostFilter` plugins](https://github.com/kubernetes/kubernetes/pull/140747) which incorrectly referenced "PostFilter plugins" instead of "PodGroupPostFilter plugins".
+* Adds a [`storage_to_cache` stage to the watch dispatch metric](https://github.com/kubernetes/kubernetes/pull/140860) for finer-grained latency observability of the watch pipeline.
+* An [`allocatedPods` Kubelet endpoint](https://github.com/kubernetes/kubernetes/pull/140856) gated by the `KubeletAllocatedPodsEndpoint` feature gate is added; this surfaces allocated-pod information from the Kubelet and backs the `/allocated` Pod subresource proposed under KEP-5972 Dynamic Containers.
+* Adds a [`cache_to_watcher` stage to the watch dispatch metric](https://github.com/kubernetes/kubernetes/pull/140851), complementing the new `storage_to_cache` stage for end-to-end latency visibility.
+* The [PVC protection controller now skips `Unused` condition evaluation for unbound PVCs](https://github.com/kubernetes/kubernetes/pull/140833), since the condition only applies to bound PVCs under the `PersistentVolumeClaimUnusedSinceTime` feature.
+* Fixes [DRA scheduler queuing hints for deleted `ResourceClaim` events](https://github.com/kubernetes/kubernetes/pull/140831), ensuring pods are re-queued when a `ResourceClaim` allocation is removed.
+* Adds an [`error` outcome to the cloud-provider `route_sync_total` metric](https://github.com/kubernetes/kubernetes/pull/140824), which previously only counted successful syncs.
+* kube-proxy/nftables: [avoids using a `numgen` map for single-endpoint service DNAT](https://github.com/kubernetes/kubernetes/pull/140723), reducing per-rule scan cost in clusters with many Services.
+
+## Promotions
+
+* [`AllowUnsafeMalformedObjectDeletion` to Beta](https://github.com/kubernetes/kubernetes/pull/140785) under KEP-3926.
+* [`PLEGOnDemandRelist` to GA](https://github.com/kubernetes/kubernetes/pull/140805).
+* [`InPlacePodVerticalScalingInitContainers` to GA](https://github.com/kubernetes/kubernetes/pull/140728).
+* [KEP-5304 metadata/downward API to Beta](https://github.com/kubernetes/kubernetes/pull/140722).
+
+## Version Updates
+* [google.golang.org/grpc to v1.82.1](https://github.com/kubernetes/kubernetes/pull/140740), a security release.
 
 ## Subprojects and Dependency Updates
 


### PR DESCRIPTION

Excluded: cherry-picks, release-note-none PRs, and PRs likely to overlap with Featured PR