### PR TITLE
Developer News for the week ending August 2, 2026.

### DIFF
--- a/_posts/2026-08-02-update.md
+++ b/_posts/2026-08-02-update.md
@@ -7,6 +7,9 @@ slug: 2026-08-02-update
 
 ## Developer News
 
+* The Kubernetes Steering Committee is [holding a Q&A session for election candidates](https://www.kubernetes.dev/resources/calendar/) at the public Steering meeting on Wednesday, August 5 at 8 AM Pacific / 11 AM Eastern.
+
+* SIG ContribEx has [merged documentation for the Kubernetes social media automation process](https://github.com/kubernetes/community/pull/9077), formalizing how community posts across project accounts are triaged, drafted, and published.
 
 ## Release Schedule
 


### PR DESCRIPTION
Excluded: prior-week Steering nominations (Janet Kuo, Sean McGinnis, Michael McCune) already covered, deadline reminders redundant with July 12 issue already being published, SIG-scoped or routine community PRs.