### PR TITLE
Week Ending August 9, 2026: Developer News

### DIFF
--- a/_posts/2026-08-09-update.md
+++ b/_posts/2026-08-09-update.md
@@ -7,6 +7,11 @@ slug: 2026-08-09-update
 
 ## Developer News
 
+* SIG Autoscaling has [clarified its sub-project donation requirements](https://github.com/kubernetes/community/pull/9079), formalizing what external projects need to satisfy to be adopted under the SIG.
+
+* Dims has [published a post-Code-Freeze CI recovery writeup](https://groups.google.com/a/kubernetes.io/g/dev/c/BBZ8j0qvGKU) showing that contributors across SIGs fixed roughly 27 CI jobs through 60 PRs since July 22, with the `sig-release-master-blocking` board now green; the [full gist](https://gist.github.com/dims/f102915bd1ce82db9ca100d0c7574d8c) lists about 30 open failing-test and flake issues that still need owners.
+
+* The [KubeCon + CloudNativeCon NA 2026 schedule](https://groups.google.com/a/kubernetes.io/g/dev/c/xWnkUk_RvNw) is now live.
 ## Election Updates
 
 ## Contributor Blog

--- a/_posts/2026-08-09-update.md
+++ b/_posts/2026-08-09-update.md
@@ -7,7 +7,7 @@ slug: 2026-08-09-update
 
 ## Developer News
 
-* SIG Autoscaling has [clarified its sub-project donation requirements](https://github.com/kubernetes/community/pull/9079), formalizing what external projects need to satisfy to be adopted under the SIG.
+* SIG Autoscaling has [clarified its subproject donation requirements](https://github.com/kubernetes/community/pull/9079), formalizing what external projects need to satisfy to be adopted under the SIG.
 
 * Dims has [published a post-Code-Freeze CI recovery writeup](https://groups.google.com/a/kubernetes.io/g/dev/c/BBZ8j0qvGKU) showing that contributors across SIGs fixed roughly 27 CI jobs through 60 PRs since July 22, with the `sig-release-master-blocking` board now green; the [full gist](https://gist.github.com/dims/f102915bd1ce82db9ca100d0c7574d8c) lists about 30 open failing-test and flake issues that still need owners.
 


### PR DESCRIPTION

Sources: dev@ mailing list and kubernetes/community merged PRs, Aug 3 - Aug 9.

Excluded from Dev News:
- v1.37.0-rc.0 release + release schedule update → Kirti's Release Schedule
- Steering election closing
- Recurring calendar syncs, unresolved issues