### PR TITLE
Week Ending August 16, 2026: Developer News

### DIFF
--- a/_posts/2026-08-16-update.md
+++ b/_posts/2026-08-16-update.md
@@ -7,6 +7,11 @@ slug: 2026-08-16-update
 
 ## Developer News
 
+* The [Kubernetes v1.38 Release Team Shadow application is now open](https://groups.google.com/a/kubernetes.io/g/dev/c/n6dG856Airk/m/NggzRDDkCgAJ); contributors interested in shadowing a role during the v1.38 cycle can apply through the [application form](https://forms.gle/Z7iwnhn1WqucBtHy6) by August 28.
+
+* containerd is [deprecating the implicit restore-via-`CreateContainer` codepath](https://groups.google.com/a/kubernetes.io/g/dev/c/O420PQSbTn8) introduced by KEP-2008 (Forensic Container Checkpointing) after multiple CVEs; containerd 2.3.4 and 2.2.7 retain it as an experimental opt-in behind `enable_experimental_restore_via_create`, and containerd 2.4 removes it in favor of the explicit `RestorePod` API from KEP-5823.
+
+* SIG ContribEx has [added AI notetaker guidance to Kubernetes Zoom meeting guidelines](https://github.com/kubernetes/community/pull/9051): "Any AI notetaker bots (such as Granola, Otter.ai, Fireflies.ai, Fathom, or Read.ai) are not permitted on Kubernetes Zoom calls. Unauthorized third-party recording poses risks around consent, privacy, and moderation."
 
 ### Election Update
 
@@ -14,8 +19,13 @@ slug: 2026-08-16-update
 
 ## Release Schedule
 
-**Next Deadline:**
+**Next Deadline: [Kubernetes v1.37.0 GA](https://github.com/kubernetes/sig-release/blob/master/releases/release_phases.md#release-day), [August 26](https://www.kubernetes.dev/resources/release/#timeline)**
 
+The v1.37 release cycle enters its final week. [Kubernetes v1.37.0-rc.1](https://groups.google.com/g/kubernetes-announce/c/DfYb5z_aA1Q) has been released, built with Go 1.26.5, following [v1.37.0-rc.0](https://groups.google.com/g/kubernetes-announce/c/z_O1FKgwqGA) on August 6. The final v1.37.0 release, and release blog publication are all targeted for August 26.
+
+[August Kubernetes patch releases have been delayed](https://groups.google.com/g/kubernetes-announce/c/4SubRAsWDyA) to Wednesday, August 19.
+
+[Kubernetes v1.38 Release Team Shadow application](https://groups.google.com/a/kubernetes.io/g/dev/c/n6dG856Airk/m/NggzRDDkCgAJ) is open through August 28, with the v1.38 release cycle expected to begin around August 31.
 
 ## Featured PRs
 


### PR DESCRIPTION
Developer News for week ending August 16, 2026.

Sources: dev@ mailing list and kubernetes/community merged PRs, Aug 10 - Aug 16.
